### PR TITLE
feat: add support for schema directive

### DIFF
--- a/example/complex_uses.graphql
+++ b/example/complex_uses.graphql
@@ -1,3 +1,8 @@
+extend schema
+	@compose(directiveName: "lowercase")
+	@compose(directiveName: "uppercase")
+	@compose(directiveName: "pascalcase")
+
 """Caching directive to control cache behavior of fields or fragments."""
 directive @cache(
   """Specifies the maximum age for cache in seconds."""

--- a/example/complex_uses.py
+++ b/example/complex_uses.py
@@ -13,6 +13,7 @@ from graphql import (
 from graphene_directives import (
     CustomDirective,
     DirectiveLocation,
+    SchemaDirective,
     build_schema,
     directive,
 )
@@ -103,6 +104,19 @@ RepeatableDirective = CustomDirective(
     args={
         "service_name": GraphQLArgument(
             GraphQLNonNull(GraphQLBoolean), description="Service Name required"
+        )
+    },
+    is_repeatable=True,
+)
+
+# A Schema directive
+ComposeDirective = CustomDirective(
+    name="compose",
+    locations=[DirectiveLocation.SCHEMA],
+    description="A schema directive.",
+    args={
+        "directive_name": GraphQLArgument(
+            GraphQLNonNull(GraphQLString), description="Directive Name required"
         )
     },
     is_repeatable=True,
@@ -256,6 +270,18 @@ schema = build_schema(
         InternalDirective,
         KeyDirective,
         RepeatableDirective,
+    ),
+    schema_directives=(  # extend schema directives
+        SchemaDirective(
+            target_directive=ComposeDirective, arguments={"directive_name": "lowercase"}
+        ),
+        SchemaDirective(
+            target_directive=ComposeDirective, arguments={"directive_name": "uppercase"}
+        ),
+        SchemaDirective(
+            target_directive=ComposeDirective,
+            arguments={"directive_name": "pascalcase"},
+        ),
     ),
 )
 

--- a/graphene_directives/__init__.py
+++ b/graphene_directives/__init__.py
@@ -1,12 +1,14 @@
 from .constants import DirectiveLocation
 from .directive import ACCEPTED_TYPES
 from .directive import CustomDirective, directive, directive_decorator
+from .data_models import SchemaDirective
 from .exceptions import DirectiveCustomValidationError, DirectiveValidationError
 from .main import build_schema
 
 __all__ = [
     "build_schema",
     "CustomDirective",
+    "SchemaDirective",
     "directive_decorator",
     "directive",
     "ACCEPTED_TYPES",

--- a/graphene_directives/data_models/__init__.py
+++ b/graphene_directives/data_models/__init__.py
@@ -1,0 +1,4 @@
+from .custom_directive_meta import CustomDirectiveMeta
+from .schema_directive import SchemaDirective
+
+__all__ = ["SchemaDirective", "CustomDirectiveMeta"]

--- a/graphene_directives/data_models/custom_directive_meta.py
+++ b/graphene_directives/data_models/custom_directive_meta.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass
+from typing import Any, Callable, Union
+
+from graphql import DirectiveLocation as GrapheneDirectiveLocation, GraphQLDirective
+
+
+@dataclass
+class CustomDirectiveMeta:
+    allow_all_directive_locations: bool
+    add_definition_to_schema: bool
+    has_no_argument: bool
+    valid_types: set[GrapheneDirectiveLocation]
+    non_field_types: set[GrapheneDirectiveLocation]
+    supports_field_types: bool
+    supports_non_field_types: bool
+    validator: Union[Callable[[GraphQLDirective, Any], bool], None]

--- a/graphene_directives/data_models/schema_directive.py
+++ b/graphene_directives/data_models/schema_directive.py
@@ -1,0 +1,24 @@
+from dataclasses import dataclass
+from typing import Any
+
+from graphql import DirectiveLocation as GrapheneDirectiveLocation
+from graphql import GraphQLDirective
+
+from ..exceptions import DirectiveValidationError
+
+
+@dataclass
+class SchemaDirective:
+    target_directive: GraphQLDirective
+    arguments: dict[str, Any]
+
+    def __post_init__(self):
+        if GrapheneDirectiveLocation.SCHEMA not in self.target_directive.locations:
+            raise DirectiveValidationError(
+                ". ".join(
+                    [
+                        f"{self.target_directive} cannot be used as schema directive",
+                        "Missing DirectiveLocation.SCHEMA in locations",
+                    ]
+                )
+            )

--- a/graphene_directives/directive.py
+++ b/graphene_directives/directive.py
@@ -1,18 +1,13 @@
-from dataclasses import dataclass
 from functools import partial
-from typing import Any, Callable, Collection, Dict, Optional, Union
+from typing import Any, Callable, Collection, Dict, Optional
 
 from graphene.utils.str_converters import to_camel_case
-from graphql import (
-    DirectiveLocation as GrapheneDirectiveLocation,
-    GraphQLArgument,
-    GraphQLDirective,
-    GraphQLNonNull,
-)
+from graphql import GraphQLArgument, GraphQLDirective, GraphQLNonNull
 from graphql.language import ast
 
 from .constants import ACCEPTED_TYPES, FIELD_TYPES, LOCATION_NON_FIELD_VALIDATOR
 from .constants import DirectiveLocation
+from .data_models import CustomDirectiveMeta
 from .exceptions import (
     DirectiveCustomValidationError,
     DirectiveInvalidArgTypeError,
@@ -20,18 +15,6 @@ from .exceptions import (
     DirectiveValidationError,
 )
 from .utils import field_attribute_name, non_field_attribute_name, set_attribute_value
-
-
-@dataclass
-class CustomDirectiveMeta:
-    allow_all_directive_locations: bool
-    add_definition_to_schema: bool
-    has_no_argument: bool
-    valid_types: set[GrapheneDirectiveLocation]
-    non_field_types: set[GrapheneDirectiveLocation]
-    supports_field_types: bool
-    supports_non_field_types: bool
-    validator: Union[Callable[[GraphQLDirective, Any], bool], None]
 
 
 def CustomDirective(  # noqa

--- a/graphene_directives/main.py
+++ b/graphene_directives/main.py
@@ -4,6 +4,8 @@ import graphene
 from graphene import Schema as GrapheneSchema
 from graphql import GraphQLDirective
 
+from . import DirectiveValidationError
+from .data_models import SchemaDirective
 from .schema import Schema
 
 
@@ -14,7 +16,18 @@ def build_schema(
     types: Collection[Union[graphene.ObjectType, Type[graphene.ObjectType]]] = None,
     directives: Union[Collection[GraphQLDirective], None] = None,
     auto_camelcase: bool = True,
+    schema_directives: Collection[SchemaDirective] = None,
 ) -> GrapheneSchema:
+    _schema_directive_set: set[str] = set()
+    for schema_directive in schema_directives or []:
+        if schema_directive.target_directive.name in _schema_directive_set:
+            if not schema_directive.target_directive.is_repeatable:
+                raise DirectiveValidationError(
+                    f"{schema_directive.target_directive} is not repeatable on schema"
+                )
+        else:
+            _schema_directive_set.add(schema_directive.target_directive.name)
+
     return Schema(
         query=query,
         mutation=mutation,
@@ -22,4 +35,5 @@ def build_schema(
         types=types,
         directives=directives,
         auto_camelcase=auto_camelcase,
+        schema_directives=schema_directives,
     )

--- a/graphene_directives/parsers.py
+++ b/graphene_directives/parsers.py
@@ -1,5 +1,5 @@
 import re
-from typing import Union
+from typing import Collection, Union
 
 from graphene.utils.str_converters import to_camel_case
 from graphql import (
@@ -15,6 +15,8 @@ from graphql.utilities.print_schema import (
     print_fields,
     print_input_object,
 )
+
+from .data_models import SchemaDirective
 
 
 def _remove_block(str_fields: str) -> str:
@@ -62,3 +64,23 @@ def decorator_string(directive: GraphQLDirective, **kwargs: dict) -> str:
 
     # Construct the directive string
     return f"{directive_name}({', '.join(formatted_args)})"
+
+
+def extend_schema_string(
+    string_schema: str, schema_directives: Collection[SchemaDirective]
+) -> str:
+    schema_directives_strings = []
+    for schema_directive in schema_directives:
+        schema_directives_strings.append(
+            "\t"
+            + decorator_string(
+                schema_directive.target_directive, **schema_directive.arguments
+            )
+        )
+
+    if len(schema_directives_strings) != 0:
+        string_schema += (
+            "extend schema\n" + "\n".join(schema_directives_strings) + "\n\n"
+        )
+
+    return string_schema

--- a/graphene_directives/schema.py
+++ b/graphene_directives/schema.py
@@ -28,12 +28,14 @@ from graphql.utilities.print_schema import (
     print_input_value,
 )
 
+from .data_models import SchemaDirective
 from .directive import CustomDirectiveMeta
 from .exceptions import DirectiveValidationError
 from .parsers import (
     decorator_string,
     entity_type_to_fields_string,
     enum_type_to_fields_string,
+    extend_schema_string,
     input_type_to_fields_string,
 )
 from .utils import (
@@ -54,9 +56,12 @@ class Schema(GrapheneSchema):
         types: list[graphene.ObjectType] = None,
         directives: Union[Collection[GraphQLDirective], None] = None,
         auto_camelcase: bool = True,
+        schema_directives: Collection[SchemaDirective] = None,
     ):
         self.directives = directives or []
+        self.schema_directives = schema_directives or []
         self.auto_camelcase = auto_camelcase
+        self.schema_directives = schema_directives or []
         super().__init__(
             query=query,
             mutation=mutation,
@@ -406,7 +411,10 @@ class Schema(GrapheneSchema):
         return directives_fields
 
     def __str__(self):
-        string_schema = print_schema(self.graphql_schema)
+        string_schema = ""
+        string_schema += extend_schema_string(string_schema, self.schema_directives)
+
+        string_schema += print_schema(self.graphql_schema)
         regex = r"schema \{(\w|\!|\s|\:)*\}"
         pattern = re.compile(regex)
         string_schema = pattern.sub(" ", string_schema)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "graphene-directives"
-version = "0.3.1"
+version = "0.3.2"
 packages = [{include = "graphene_directives"}]
 description = "Schema Directives implementation for graphene"
 authors = ["Strollby <developers@strollby.com>"]

--- a/tests/schema_files/test_directive.graphql
+++ b/tests/schema_files/test_directive.graphql
@@ -1,3 +1,9 @@
+extend schema
+	@link(url: "https://spec.graphql.org/v1.0")
+	@compose(directiveName: "lowercase")
+	@compose(directiveName: "uppercase")
+	@compose(directiveName: "lowercase")
+
 """Caching directive to control cache behavior of fields or fragments."""
 directive @cache(
   """Specifies the maximum age for cache in seconds."""
@@ -20,7 +26,10 @@ directive @authenticated(
 directive @hidden on OBJECT | ARGUMENT_DEFINITION
 
 """Schema directive to link files"""
-directive @link on SCHEMA
+directive @link(
+  """Url required"""
+  url: String!
+) on SCHEMA
 
 union SearchResult @cache(maxAge: 500) @authenticated(required: True) = Human | Droid | Starship
 

--- a/tests/test_directive.py
+++ b/tests/test_directive.py
@@ -13,6 +13,7 @@ from graphql import (
 from graphene_directives import (
     CustomDirective,
     DirectiveLocation,
+    SchemaDirective,
     build_schema,
     directive,
 )
@@ -84,11 +85,30 @@ HiddenDirective = CustomDirective(
 )
 
 
-# No argument directive
+# No Schema  directive
 LinkDirective = CustomDirective(
     name="link",
     locations=[DirectiveLocation.SCHEMA],
     description="Schema directive to link files",
+    args={
+        "url": GraphQLArgument(
+            GraphQLNonNull(GraphQLString), description="Url required"
+        )
+    },
+)
+
+
+# A Schema directive
+ComposeDirective = CustomDirective(
+    name="compose",
+    locations=[DirectiveLocation.SCHEMA],
+    description="A schema directive.",
+    args={
+        "directive_name": GraphQLArgument(
+            GraphQLNonNull(GraphQLString), description="Directive Name required"
+        )
+    },
+    is_repeatable=True,
 )
 
 
@@ -220,6 +240,21 @@ schema = build_schema(
     query=Query,
     types=(SearchResult, Animal, Admin, HumanInput, TruthEnum, DateNewScalar, User),
     directives=(CacheDirective, AuthenticatedDirective, HiddenDirective, LinkDirective),
+    schema_directives=(  # extend schema directives
+        SchemaDirective(
+            target_directive=LinkDirective,
+            arguments={"url": "https://spec.graphql.org/v1.0"},
+        ),
+        SchemaDirective(
+            target_directive=ComposeDirective, arguments={"directive_name": "lowercase"}
+        ),
+        SchemaDirective(
+            target_directive=ComposeDirective, arguments={"directive_name": "uppercase"}
+        ),
+        SchemaDirective(
+            target_directive=ComposeDirective, arguments={"directive_name": "lowercase"}
+        ),
+    ),
 )
 
 


### PR DESCRIPTION
Add support for schema directives

```python

# No argument directive
LinkDirective = CustomDirective(
    name="link",
    locations=[DirectiveLocation.SCHEMA],
    description="Schema directive to link files",
    args={
        "url": GraphQLArgument(
            GraphQLNonNull(GraphQLString), description="Url required"
        )
    },
)

# A Schema directive
ComposeDirective = CustomDirective(
    name="compose",
    locations=[DirectiveLocation.SCHEMA],
    description="A schema directive.",
    args={
        "directive_name": GraphQLArgument(
            GraphQLNonNull(GraphQLString), description="Directive Name required"
        )
    },
    is_repeatable=True,
)

schema = build_schema(
    query=Query,
    types=(SearchResult, Animal, Admin, HumanInput, TruthEnum, DateNewScalar, User),
    directives=(CacheDirective, AuthenticatedDirective, HiddenDirective, LinkDirective),
    schema_directives=(  # extend schema directives
        SchemaDirective(
            target_directive=LinkDirective,
            arguments={"url": "https://spec.graphql.org/v1.0"},
        ),
        SchemaDirective(
            target_directive=ComposeDirective, arguments={"directive_name": "lowercase"}
        ),
        SchemaDirective(
            target_directive=ComposeDirective, arguments={"directive_name": "uppercase"}
        ),
        SchemaDirective(
            target_directive=ComposeDirective, arguments={"directive_name": "lowercase"}
        ),
    ),
)

```