### PR TITLE
Support multi-line strings in field descriptions or deprecation reasons

### DIFF
--- a/graphene_directives/schema.py
+++ b/graphene_directives/schema.py
@@ -379,8 +379,12 @@ class Schema(GrapheneSchema):
                 r"(%s\s%s\s[^\{]*)\{\s*%s\s*\}"  # noqa
                 % (entity_type_name, entity_name, re.escape(str_fields_original))
             )
+
+            # Escape backslashes to ensure that `\\n` is not replaced with a newline character
+            # see: https://github.com/strollby/graphene-directives/pull/10
+            escaped_str_fields_annotated = str_fields_annotated.replace("\\", "\\\\")
             string_schema = pattern.sub(
-                r"\g<1> {\n%s\n}" % str_fields_annotated, string_schema
+                r"\g<1> {\n%s\n}" % escaped_str_fields_annotated, string_schema
             )
         return string_schema
 

--- a/tests/schema_files/test_directive_multiline_string_no_directive.graphql
+++ b/tests/schema_files/test_directive_multiline_string_no_directive.graphql
@@ -1,0 +1,12 @@
+schema {
+  query: QueryNoDirective
+}
+
+type QueryNoDirective {
+  position: Position @deprecated(reason: "Koo\n\nDeprecated on 2025-01-01")
+}
+
+type Position {
+  x: Int!
+  y: Int!
+}

--- a/tests/schema_files/test_directive_multiline_string_with_directive.graphql
+++ b/tests/schema_files/test_directive_multiline_string_with_directive.graphql
@@ -1,0 +1,24 @@
+schema {
+  query: QueryWithDirective
+}
+
+"""Caching directive to control cache behavior of fields or fragments."""
+directive @cache(
+  """Specifies the maximum age for cache in seconds."""
+  maxAge: Int!
+
+  """Stale-while-revalidate value in seconds. Optional."""
+  swr: Int
+
+  """Scope of the cache. Optional."""
+  scope: String
+) on OBJECT | INTERFACE | ENUM | UNION | INPUT_OBJECT | FIELD_DEFINITION | INPUT_FIELD_DEFINITION | SCALAR
+
+type QueryWithDirective  {
+  position: Position @deprecated(reason: "Koo\n\nDeprecated on 2025-01-01") @cache(maxAge: 300)
+}
+
+type Position {
+  x: Int!
+  y: Int!
+}

--- a/tests/test_directive_multiline_strings.py
+++ b/tests/test_directive_multiline_strings.py
@@ -1,0 +1,109 @@
+from pathlib import Path
+from typing import Any
+
+import graphene
+from graphql import GraphQLArgument, GraphQLInt, GraphQLNonNull, GraphQLString
+
+from graphene_directives import (
+    CustomDirective,
+    DirectiveLocation,
+    Schema,
+    build_schema,
+    directive,
+)
+
+curr_dir = Path(__file__).parent
+
+
+def validate_non_field_input(_type: Any, inputs: dict, _schema: Schema) -> bool:
+    """
+    def validator (type_: graphene type, inputs: Any, schema: Schema) -> bool,
+    if validator returns False, library raises DirectiveCustomValidationError
+    """
+    if inputs.get("max_age") > 2500:
+        return False
+    return True
+
+
+def validate_field_input(
+    _parent_type: Any, _field_type: Any, inputs: dict, _schema: Schema
+) -> bool:
+    """
+    def validator (parent_type_: graphene_type, field_type_: graphene type, inputs: Any, schema: Schema) -> bool,
+    if validator returns False, library raises DirectiveCustomValidationError
+    """
+    if inputs.get("max_age") > 2500:
+        return False
+    return True
+
+
+CacheDirective = CustomDirective(
+    name="cache",
+    locations=[
+        DirectiveLocation.OBJECT,
+        DirectiveLocation.INTERFACE,
+        DirectiveLocation.ENUM,
+        DirectiveLocation.UNION,
+        DirectiveLocation.INPUT_OBJECT,
+        DirectiveLocation.FIELD_DEFINITION,
+        DirectiveLocation.INPUT_FIELD_DEFINITION,
+        DirectiveLocation.SCALAR,
+    ],
+    args={
+        "max_age": GraphQLArgument(
+            GraphQLNonNull(GraphQLInt),
+            description="Specifies the maximum age for cache in seconds.",
+        ),
+        "swr": GraphQLArgument(
+            GraphQLInt, description="Stale-while-revalidate value in seconds. Optional."
+        ),
+        "scope": GraphQLArgument(
+            GraphQLString, description="Scope of the cache. Optional."
+        ),
+    },
+    description="Caching directive to control cache behavior of fields or fragments.",
+    non_field_validator=validate_non_field_input,
+    field_validator=validate_field_input,
+)
+
+
+class Position(graphene.ObjectType):
+    x = graphene.Int(required=True)
+    y = graphene.Int(required=True)
+
+
+class QueryNoDirective(graphene.ObjectType):
+    position = graphene.Field(
+        Position, deprecation_reason="Koo\n\nDeprecated on 2025-01-01"
+    )
+
+
+class QueryWithDirective(graphene.ObjectType):
+    position = directive(
+        CacheDirective,
+        field=graphene.Field(
+            Position, deprecation_reason="Koo\n\nDeprecated on 2025-01-01"
+        ),
+        max_age=300,
+    )
+
+
+schema_no_directive = build_schema(query=QueryNoDirective)
+
+schema_with_directive = build_schema(
+    query=QueryWithDirective, directives=(CacheDirective,)
+)
+
+
+def test_generate_schema_no_directive() -> None:
+    with open(
+        f"{curr_dir}/schema_files/test_directive_multiline_string_no_directive.graphql"
+    ) as f:
+        assert str(schema_no_directive) == f.read()
+
+
+def test_generate_schema_with_directive() -> None:
+    with open(
+        f"{curr_dir}/schema_files/test_directive_multiline_string_with_directive.graphql"
+    ) as f:
+        assert str(schema_with_directive) == f.read()


### PR DESCRIPTION
## What is this PR trying to fix?
When using `\n` characters in field descriptions or in a deprecation reason, an invalid SLD schema would be generated.

## Example
This field uses a deprecation reason with `\n` characters:
```
class QueryWithDirective(graphene.ObjectType):
    position = directive(
        CacheDirective,
        field=graphene.Field(
            Position, deprecation_reason="Koo\n\nDeprecated on 2025-01-01"
        ),
        max_age=300,
    )
```

Without the directive, a valid SLD is generated. But as soon as a directive is used, an invalid SLD is generated:
```
type QueryWithDirective  {
  position: Position @deprecated(reason: "Koo

Deprecated on 2025-01-01") @cache(maxAge: 300)
}
```

The schema linter fails for this SLD because of an unterminated string.

## What is the underlying problem?
When a field definition with a directive is inserted into the schema [using regex](https://github.com/strollby/graphene-directives/blob/068f2660ab207cbbb452114a525d64a4bc962ee8/graphene_directives/schema.py#L377-L383), [re.sub](https://docs.python.org/3/library/re.html#re.sub) replaces `\n` with a newline character. This leads to the invalid SLD.

## What is the proposed fix?
Before calling `re.sub`, all backslashes are escaped so that `\n` is not converted to a newline character (as suggested in the [re documentation](https://docs.python.org/3/library/re.html#re.escape)).
