### PR TITLE
Make sure argument names are converted to camelCase

### DIFF
--- a/graphene_directives/schema.py
+++ b/graphene_directives/schema.py
@@ -152,6 +152,7 @@ class Schema(GrapheneSchema):
         str_field = "(" if print_single_line else "(\n"
 
         for i, (name, arg) in enumerate(args.items()):
+            name = self.type_attribute_to_field_name(name)
             if print_single_line:
                 base_str = f"{print_input_value(name, arg)} "
             else:

--- a/tests/schema_files/test_directive_arguments_camel_case.graphql
+++ b/tests/schema_files/test_directive_arguments_camel_case.graphql
@@ -1,0 +1,28 @@
+schema {
+  query: QueryWithDirective
+}
+
+"""Caching directive to control cache behavior of fields or fragments."""
+directive @cache(
+  """Specifies the maximum age for cache in seconds."""
+  maxAge: Int!
+
+  """Stale-while-revalidate value in seconds. Optional."""
+  swr: Int
+
+  """Scope of the cache. Optional."""
+  scope: String
+) repeatable on OBJECT | FIELD_DEFINITION
+
+type QueryWithDirective  {
+  position: Position @cache(maxAge: 300)
+  """A question"""
+  question(formId: Int! ): String
+  """A score"""
+  score(formId: Int! ): Int
+}
+
+type Position {
+  x: Int!
+  y: Int!
+}

--- a/tests/test_directive_arguments.py
+++ b/tests/test_directive_arguments.py
@@ -4,7 +4,12 @@ import graphene
 import pytest
 from graphql import GraphQLArgument, GraphQLInt, GraphQLNonNull, GraphQLString
 
-from graphene_directives import CustomDirective, DirectiveLocation, directive
+from graphene_directives import (
+    CustomDirective,
+    DirectiveLocation,
+    directive,
+    build_schema,
+)
 from graphene_directives.exceptions import DirectiveInvalidArgValueTypeError
 
 curr_dir = Path(__file__).parent
@@ -45,6 +50,28 @@ DbCacheDirective = CustomDirective(
         ),
     },
     description="Caching directive to control cache behavior of fields or fragments.",
+)
+
+
+class Position(graphene.ObjectType):
+    x = graphene.Int(required=True)
+    y = graphene.Int(required=True)
+
+
+class QueryWithDirective(graphene.ObjectType):
+    position = directive(CacheDirective, field=graphene.Field(Position), max_age=300)
+
+    question = graphene.Field(
+        graphene.String, form_id=graphene.Int(required=True), description="A question"
+    )
+
+    score = graphene.Field(
+        graphene.Int, form_id=graphene.Int(required=True), description="A score"
+    )
+
+
+schema_with_directive = build_schema(
+    query=QueryWithDirective, directives=(CacheDirective,)
 )
 
 
@@ -90,3 +117,11 @@ def test_input_default_argument_on_field() -> None:
                 deprecation_reason="This field is deprecated and will be removed in future",
             ),
         )
+
+
+def test_generate_schema_with_arguments() -> None:
+    """Test that argument names are converted to camel-case."""
+    with open(
+        f"{curr_dir}/schema_files/test_directive_arguments_camel_case.graphql"
+    ) as f:
+        assert str(schema_with_directive) == f.read()


### PR DESCRIPTION
## What is this PR trying to fix?

When generating a SLD, sometimes the attribute names would not be converted to camelCase (even though `auto_camelcase` is set to `True`).

## Example
The following schema has a field with a directive and a field with an input argument (`form_id`):
```
class QueryWithDirective(graphene.ObjectType):
    position = directive(CacheDirective, field=graphene.Field(Position), max_age=300)

    question = graphene.Field(
        graphene.String, form_id=graphene.Int(required=True), description="A question"
    )
```

So far, the following SLD is generated. The argument `form_id` is not converted to camelCase:
```
type QueryWithDirective  {
  position: Position @cache(maxAge: 300)
  """A question"""
  question(form_id: Int! ): String
  ...
```

With the proposed fix, the argument is converted to camelCase:

```
type QueryWithDirective  {
  position: Position @cache(maxAge: 300)
  """A question"""
  question(formId: Int! ): String
  ...
```